### PR TITLE
Lower text bound

### DIFF
--- a/ghcjs-websockets.cabal
+++ b/ghcjs-websockets.cabal
@@ -82,7 +82,7 @@ maintainer:          Justin Le <justin@jle.im>
 copyright:           Copyright (c) Justin Le 2015
 category:            Web
 build-type:          Simple
--- extra-source-files:  
+-- extra-source-files:
 cabal-version:       >=1.10
 
 source-repository head
@@ -95,7 +95,7 @@ library
   -- ghcjs-options: -O2
   other-modules:       JavaScript.Blob
                      , JavaScript.WebSockets.FFI
-  -- other-extensions:    
+  -- other-extensions:
   ghc-options:         -Wall
   build-depends:       base              >= 4.7      && < 5
                      , base64-bytestring >= 1

--- a/ghcjs-websockets.cabal
+++ b/ghcjs-websockets.cabal
@@ -102,6 +102,6 @@ library
                      , binary            >= 0.7
                      , bytestring        >= 0.10
                      , ghcjs-base        >= 0.1
-                     , text              >= 1.2
+                     , text              >= 1
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/src/JavaScript/Blob.hs
+++ b/src/JavaScript/Blob.hs
@@ -32,6 +32,3 @@ readBlob b = bufferByteString 0 0 =<< mask_ (ffi_readBlob b)
 
 isBlob :: JSRef a -> IO Bool
 isBlob ref = ffi_blobCheck ref
-
-
-

--- a/src/JavaScript/WebSockets.hs
+++ b/src/JavaScript/WebSockets.hs
@@ -438,4 +438,3 @@ receiveEither = fmap unwrapReceivable . receiveMessage
 -- | Returns the origin url of the given 'Connection'.
 connectionOrigin :: Connection -> Text
 connectionOrigin = _connOrigin
-

--- a/src/JavaScript/WebSockets/Internal.hs
+++ b/src/JavaScript/WebSockets/Internal.hs
@@ -395,4 +395,3 @@ _loadJSMessage msg | isNull msg = return Nothing
       else do
         let blob = unsafeCoerce msg :: JSString
         return . Just . SocketMsgText . fromJSString $ blob
-


### PR DESCRIPTION
I've got text 1.1 locally (using a stackage snapshot), but based on the imports of Data.Text, >= 1 is sufficient (lower would work too, but I didn't bother figuring out where in 0.11 `decodeUtf8'` got added).

If you mind mixing in formatting changes into this PR, I can put that in a separate one.
